### PR TITLE
Fixed connection leak

### DIFF
--- a/Rexfile
+++ b/Rexfile
@@ -40,7 +40,6 @@ task 'deploy', group => 'all', sub {
   my $live_version = eval {
     readlink $deploy_current;
   };
-  $live_version = basename($live_version) if $live_version;
 
   run "ln -snf $deploy_dir $deploy_current";
 
@@ -56,8 +55,8 @@ task 'deploy', group => 'all', sub {
     mkdir "$shared_dir/log";
   }
 
-  if (is_dir("$live_version/local")) {
-    cp "$live_version/local", "$deploy_current/local"
+  if ($live_version && is_dir("$live_version/local")) {
+    run "cp -R $live_version/local $deploy_current/local";
   }
 
   my $config_file = "$shared_dir/pmltq_server.private.pl";

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires 'Mojolicious', '6.11';
 requires 'DBIx::Class', '0.082820';
-requires 'PMLTQ', '0.8.3';
+requires 'PMLTQ', '1.1.0';
 
 requires 'DateTime', '1.18';
 requires 'DateTime::Format::Strptime', '1.56';

--- a/lib/PMLTQ/Server/Controller/Query.pm
+++ b/lib/PMLTQ/Server/Controller/Query.pm
@@ -151,6 +151,7 @@ sub query {
     while (my $row = $evaluator->cursor_next()) {
       push @results, $row;
     }
+    $evaluator->close_cursor();
 
     return $self->status_error({
       code => 500,

--- a/lib/PMLTQ/Server/Schema/Result/Treebank.pm
+++ b/lib/PMLTQ/Server/Schema/Result/Treebank.pm
@@ -2,12 +2,13 @@ package PMLTQ::Server::Schema::Result::Treebank;
 
 use Mojo::Base qw/PMLTQ::Server::Schema::Result/;
 
+use File::Spec;
+use PMLTQ::Common;
 use PMLTQ::Server::JSON 'json';
 use PMLTQ::SQLEvaluator;
-use Treex::PML;
-use File::Spec;
+use Scalar::Util 'weaken';
 use Treex::PML::Schema;
-use PMLTQ::Common;
+use Treex::PML;
 use URI;
 
 __PACKAGE__->table('treebanks');
@@ -184,13 +185,11 @@ Note: C<$evaluator> and C<$evaluator2> are actually the same instances.
 
 =cut
 
-my $evaluators = {};
-
 sub get_evaluator {
   my $self = shift;
   my $key = $self->id;
 
-  unless ($evaluators->{$key}) {
+  unless ($self->{_evaluator}) {
     my $server = $self->server;
     my $evaluator = PMLTQ::SQLEvaluator->new(undef, {
       connect => {
@@ -203,10 +202,10 @@ sub get_evaluator {
       }
     });
     $evaluator->connect();
-    $evaluators->{$key} = $evaluator;
+    $self->{_evaluator} = $evaluator;
   }
 
-  return $evaluators->{$key};
+  return $self->{_evaluator};
 }
 
 =head2 record_history
@@ -294,7 +293,7 @@ sub locate_file {
   my ($self, $f) = @_;
   my $evaluator = $self->get_evaluator();
   my $schemas = $evaluator->run_sql_query(qq{SELECT "root","data_dir","schema_file" FROM "#PML"},
-                                          { RaiseError=>1 });
+                                          { RaiseError=>1, AutoInactiveDestroy=>1 });
   for my $schema (@$schemas) {
     for my $what ('__#files','__#references') {
       my $n = $schema->[0].$what;
@@ -302,6 +301,7 @@ sub locate_file {
       # print STDERR "testing: $what $n $f\n";
       my $count = $evaluator->run_sql_query(qq{SELECT count(1) FROM "$n" WHERE "file"=?}, {
           RaiseError=>1,
+          AutoInactiveDestroy=>1,
           Bind=>[ $f ],
         });
       if ($count->[0][0]) {
@@ -393,6 +393,7 @@ sub generate_doc {
         if (ref($sth) and !$sth->err) {
           my $row = $sth->fetch;
           $doc{value} = $row->[0];
+          $sth->finish;
         }
         last SCHEMA;
       }
@@ -400,6 +401,19 @@ sub generate_doc {
   }
 
   return \%doc;
+}
+
+sub DESTORY {
+  my $self = shift;
+
+  # cleanup connection
+  if ($self->{_evaluator}) {
+    if ($self->{_evaluator}->{dbi}) {
+      $self->{_evaluator}->{dbi}->disconnect();
+      undef $self->{_evaluator}->{dbi};
+    }
+    undef $self->{_evaluator};
+  }
 }
 
 1;

--- a/t/api_treebank.t
+++ b/t/api_treebank.t
@@ -35,6 +35,11 @@ isa_ok($e2, 'PMLTQ::SQLEvaluator');
 
 is($e1, $e2, 'Evaluators are the same');
 
+undef $tb;
+$tb = test_treebank();
+$e2 = $tb->get_evaluator;
+isnt($e1, $e2, 'Evaluators are not the same');
+
 ## History tested in history.t
 
 ## Search

--- a/t/bootstrap.pl
+++ b/t/bootstrap.pl
@@ -132,11 +132,10 @@ sub test_server {
 }
 
 sub test_treebank {
-  return $test_tb if $test_tb;
-
   my $treebanks = test_db->resultset('Treebank');
   my $server = test_server();
-  $test_tb = $treebanks->create({
+  return $treebanks->recursive_update({
+    id => 1,
     name => 'pdt20_mini',
     title => 'PDT 2.0 Sample',
     server_id => $server->id,
@@ -148,8 +147,6 @@ sub test_treebank {
       { layer => 'tdata', path => File::Spec->catdir('pdt20_mini', 'data') },
     ]
   })->discard_changes;
-
-  return $test_tb
 }
 
 sub test_user {


### PR DESCRIPTION
Closing connection every time the treebank object is destroyed.

This should solve the connection leaks that can happen. This also allows databases to be freely deleted as there should be no hanging connections.
